### PR TITLE
Support other type of image extensions

### DIFF
--- a/ucollage
+++ b/ucollage
@@ -73,6 +73,8 @@ help(){
 
 read_images() {
     images=()
+    extensions=(bmp gif ico jpg jpeg png tif tiff webp)
+    joined_extension="$(local IFS="|"; shift; echo "${extensions[*]}")"
     if [[ "$#" -gt 0 ]]
     then
         filelist=("$@")
@@ -81,7 +83,16 @@ read_images() {
     fi
     for file in "${filelist[@]}"
     do
-        [[ $(file --mime-type -b "$file") =~ ^image/.*$ ]] && images+=("$file")
+        if [[ "${file,,}" =~ .${joined_extension,,}$ ]]
+        then
+            images+=("$file")
+        else
+            if [[ $(file --mime-type -b "$file") =~ ^image/.*$ ]]
+            then
+                images+=("$file")
+                joined_extension+="|${file##*.}"
+            fi
+        fi
     done
 }
 

--- a/ucollage
+++ b/ucollage
@@ -81,7 +81,7 @@ read_images() {
     fi
     for file in "${filelist[@]}"
     do
-        file "$file" | grep -qE 'image data,|bitmap,' && images+=("$file")
+        [[ $(file --mime-type -b "$file") =~ ^image/.*$ ]] && images+=("$file")
     done
 }
 

--- a/ucollage
+++ b/ucollage
@@ -75,16 +75,14 @@ read_images() {
     images=()
     if [[ "$#" -gt 0 ]]
     then
-        for file in "$@"
-        do
-            [[ "$file" =~ .jpg$|.png$ ]] && images+=("$file")
-        done
+        filelist=("$@")
     else
-        for file in *
-        do
-            [[ "$file" =~ .jpg$|.png$ ]] && images+=("$file")
-        done
+        filelist=(*)
     fi
+    for file in "${filelist[@]}"
+    do
+        file "$file" | grep -qE 'image data,|bitmap,' && images+=("$file")
+    done
 }
 
 clear_screen() {


### PR DESCRIPTION
In this PR, I use `file` command to check whether a file type contains `image data` or `bitmap`, if yes, then it's an image file.
This change will make ucollage support other type of image extensions.