### PR TITLE
Allow monocle mode for only 1 image

### DIFF
--- a/ucollage
+++ b/ucollage
@@ -117,7 +117,7 @@ clear_status() {
 }
 
 clear_names() {
-    # clear from 4th line and down 
+    # clear from 4th line and down
     printf "\e[?25l\e[H\e[3B\e[2K\e[0J\e[H"
 }
 
@@ -179,8 +179,8 @@ show_batch() {
     if [[ "$show_names" -eq 1 ]] && [[ "$show" -gt 1 ]]
     then
         # Substracting 3 lines is a hack. The names can be printed in
-        # two lines, but ueberzug is not exact in its drawing on the 
-        # terminal lines for different window sizes. 
+        # two lines, but ueberzug is not exact in its drawing on the
+        # terminal lines for different window sizes.
         # So I give it some more room for error.
         (( draw_lines = photo_lines - 3 ))
         line_names=()
@@ -495,7 +495,6 @@ rename() {
 }
 
 goto_image() {
-    [[ "$show" -eq 1 ]] && return
     if [[ -n "$1" ]]
     then
         input="$1"


### PR DESCRIPTION
In this PR:
- Remove some trailing spaces
- Allow entering monocle mode even there is only 1 image

Maybe there is some reason to not allow monocle mode for only 1 image? If it's my mistake, please reject this PR.