### PR TITLE
Fix nonexistent image name

### DIFF
--- a/ucollage
+++ b/ucollage
@@ -128,7 +128,7 @@ clear_status() {
 }
 
 clear_names() {
-    # clear from 4th line and down 
+    # clear from 4th line and down
     printf "\e[?25l\e[H\e[3B\e[2K\e[0J\e[H"
 }
 
@@ -190,8 +190,8 @@ show_batch() {
     if [[ "$show_names" -eq 1 ]] && [[ "$show" -gt 1 ]]
     then
         # Substracting 3 lines is a hack. The names can be printed in
-        # two lines, but ueberzug is not exact in its drawing on the 
-        # terminal lines for different window sizes. 
+        # two lines, but ueberzug is not exact in its drawing on the
+        # terminal lines for different window sizes.
         # So I give it some more room for error.
         (( draw_lines = photo_lines - 3 ))
         line_names=()
@@ -211,7 +211,7 @@ show_batch() {
                 assoc=( [action]=remove \
                         [identifier]="${fifo}${i}${j}" )
             else
-                if [[ "$show_names" -eq 1 ]] && [[ "$show" -gt 1 ]]
+                if [[ "$show_names" -eq 1 ]] && [[ "$show" -gt 1 ]] && [[ -n "${images[$index]}" ]]
                 then
                     (( current_number = i * fit_horizontal + j + 1 ))
                     current_name="${current_number}: $(basename "${images[$index]}")"

--- a/ucollage
+++ b/ucollage
@@ -436,6 +436,7 @@ print_info() {
     then
         ((begin = start + 1))
         ((finish = begin + show - 1))
+        [[ "$finish" -gt "$total" ]] && finish="$total"
         info+=" - Photos [$begin - $finish] of $total"
     else
         ((begin = start + 1))


### PR DESCRIPTION
In some case, ucollage will show nonexistent images e.g:

- Open images (less than 3x4=12)
- Press `m` to monocle mode
- Press `n` to go to next image
- Press `M` to go back to main screen
- Press `N` to go previous bath

Some nonexistent  image name will show like this
![1602061180](https://user-images.githubusercontent.com/14293537/95310680-fc85c180-088c-11eb-8a21-73cb50cea2fe.jpg)

In this example, all 8 images are opened, there is no image `9` to `12`.