### PR TITLE
Add option to sort image files

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,27 +96,27 @@ You can set default values for some of the variables. You just have to export th
 
 ``` bash
 # number of lines when the scripts starts
-export UCOLLAGE_LINES=2                    # valid: integer         default: 3
+export UCOLLAGE_LINES=2                    # valid: integer                           default: 3
 
 # number of columns when the scripts starts
-export UCOLLAGE_COLUMNS=2                  # valid: integer         default: 4
+export UCOLLAGE_COLUMNS=2                  # valid: integer                           default: 4
 
 # temporary directory to store script relevant files
-export UCOLLAGE_TMP_DIR="/tmp/directory"   # valid: string          default: "/tmp/ucollage"
+export UCOLLAGE_TMP_DIR="/tmp/directory"   # valid: string                            default: "/tmp/ucollage"
 
 # whether or not to ask for confirmation when executing commands
 # in monocle mode
-export UCOLLAGE_EXEC_PROMPT=1              # valid: {0, 1}          default: 0
+export UCOLLAGE_EXEC_PROMPT=1              # valid: {0, 1}                            default: 0
 
 # whether or not show the names of all images in the wide view
-export UCOLLAGE_SHOW_NAMES=1               # valid: {0, 1}          default: 1
+export UCOLLAGE_SHOW_NAMES=1               # valid: {0, 1}                            default: 1
 
 # whether or not directories should be expanded when given as arguments
-export UCOLLAGE_EXPAND_DIRS=ask            # valid: {0, 1, ask}     default: ask
+export UCOLLAGE_EXPAND_DIRS=ask            # valid: {0, 1, ask}                       default: ask
 
 # sort image files by name, time, size or extension
 export UCOLLAGE_SORT_BY=name               # valid: {name, time, size, extension}     default: name
 
 # whether or not image files should be sorted in reverse order
-export UCOLLAGE_SORT_REVERSE=0             # valid: {0, 1}     default: 0
+export UCOLLAGE_SORT_REVERSE=0             # valid: {0, 1}                            default: 0
 ```

--- a/README.md
+++ b/README.md
@@ -113,4 +113,10 @@ export UCOLLAGE_SHOW_NAMES=1               # valid: {0, 1}          default: 1
 
 # whether or not directories should be expanded when given as arguments
 export UCOLLAGE_EXPAND_DIRS=ask            # valid: {0, 1, ask}     default: ask
+
+# sort image files by name, time, size or extension
+export UCOLLAGE_SORT_BY=name               # valid: {name, time, size, extension}     default: name
+
+# whether or not image files should be sorted in reverse order
+export UCOLLAGE_SORT_REVERSE=0             # valid: {0, 1}     default: 0
 ```

--- a/ucollage
+++ b/ucollage
@@ -21,6 +21,12 @@ parse_config() {
     [[ -n "$UCOLLAGE_EXPAND_DIRS" ]] && [[ ! "$UCOLLAGE_EXPAND_DIRS" =~ ^(0|1|ask)$ ]] \
         && config_error "UCOLLAGE_EXPAND_DIRS" "$UCOLLAGE_EXPAND_DIRS" " - valid values: 0, 1" \
         && unset UCOLLAGE_EXPAND_DIRS && errors=1
+    [[ -n "$UCOLLAGE_SORT_BY" ]] && [[ ! "$UCOLLAGE_SORT_BY" =~ ^(name|time|size|extension)$ ]] \
+        && config_error "UCOLLAGE_SORT_BY" "$UCOLLAGE_SORT_BY" " - valid values: name, time, size, extension" \
+        && unset UCOLLAGE_SORT_BY && errors=1
+    [[ -n "$UCOLLAGE_SORT_REVERSE" ]] && [[ ! "$UCOLLAGE_SORT_REVERSE" =~ ^(0|1)$ ]] \
+        && config_error "UCOLLAGE_SORT_REVERSE" "$UCOLLAGE_SORT_REVERSE" " - valid values: 0, 1" \
+        && unset UCOLLAGE_SORT_REVERSE && errors=1
 
     [[ "$errors" -eq 1 ]] && read -rsN1
     unset errors
@@ -33,6 +39,8 @@ set_defaults() {
     exec_prompt=${UCOLLAGE_EXEC_PROMPT:-0}
     show_names=${UCOLLAGE_SHOW_NAMES:-1}
     expand_dirs=${UCOLLAGE_EXPAND_DIRS:-"ask"}
+    sort_by=${UCOLLAGE_SORT_BY:-name}
+    sort_reverse=${UCOLLAGE_SORT_REVERSE:0}
     error=""
     warning=""
     success=""
@@ -86,11 +94,26 @@ check_dependencies() {
 }
 
 pre_read_images() {
+    list_file_cmd="ls -d"
+    [[ "$sort_reverse" -eq 1 ]] && list_file_cmd+=" -r"
+    if [[ "$sort_by" == "name" ]]
+    then
+        list_file_cmd+=""
+    elif [[ "$sort_by" == "time" ]]
+    then
+        list_file_cmd+=" -t"
+    elif [[ "$sort_by" == "size" ]]
+    then
+        list_file_cmd+=" -S"
+    elif [[ "$sort_by" == "extension" ]]
+    then
+        list_file_cmd+=" -X"
+    fi
     if [[ "$#" -gt 0 ]]
     then
-        filelist=("$@")
+        mapfile -t filelist < <(eval "$list_file_cmd $*")
     else
-        filelist=(*)
+        mapfile -t filelist < <(eval "$list_file_cmd *")
     fi
     if [[ "$expand_dirs" -eq 1 ]]
     then


### PR DESCRIPTION
Implement #6

Add option `UCOLLAGE_SORT_BY` to sort image files by `name`, `time`, `size`, or `extension`, default `name`
Add option `UCOLLAGE_SORT_REVERSE` to sort in the reverse order, default `0`